### PR TITLE
✨ Feat: 프로모션 목록 조회

### DIFF
--- a/src/main/java/com/f012r/naverbooking/domain/products/entity/FileInfo.java
+++ b/src/main/java/com/f012r/naverbooking/domain/products/entity/FileInfo.java
@@ -1,0 +1,37 @@
+package com.f012r.naverbooking.domain.products.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "file_info")
+public class FileInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "save_file_name", nullable = false, length = 4000)
+    private String saveFileName;
+
+    @Column(name = "content_type", nullable = false)
+    private String contentType;
+
+    @Column(name = "delete_flag", nullable = false)
+    private Integer deleteFlag;
+
+    @Column(name = "create_date")
+    private Instant createDate;
+
+    @Column(name = "modify_date")
+    private Instant modifyDate;
+
+}

--- a/src/main/java/com/f012r/naverbooking/domain/products/entity/ProductImage.java
+++ b/src/main/java/com/f012r/naverbooking/domain/products/entity/ProductImage.java
@@ -1,0 +1,28 @@
+package com.f012r.naverbooking.domain.products.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "product_image")
+public class ProductImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "type", nullable = false, length = 2)
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "file_id", nullable = false)
+    private FileInfo file;
+
+}

--- a/src/main/java/com/f012r/naverbooking/domain/products/repository/ProductImageRepository.java
+++ b/src/main/java/com/f012r/naverbooking/domain/products/repository/ProductImageRepository.java
@@ -1,0 +1,12 @@
+package com.f012r.naverbooking.domain.products.repository;
+
+import com.f012r.naverbooking.domain.products.entity.Product;
+import com.f012r.naverbooking.domain.products.entity.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Integer> {
+
+    Optional<ProductImage> findFirstByProductAndType(Product product, String imageType);
+}

--- a/src/main/java/com/f012r/naverbooking/domain/promotions/controller/PromotionsController.java
+++ b/src/main/java/com/f012r/naverbooking/domain/promotions/controller/PromotionsController.java
@@ -1,0 +1,33 @@
+package com.f012r.naverbooking.domain.promotions.controller;
+
+import com.f012r.naverbooking.domain.promotions.dto.PromotionsResponseDTO;
+import com.f012r.naverbooking.domain.promotions.service.PromotionsService;
+import com.f012r.naverbooking.global.common.ResponseDTO;
+import com.f012r.naverbooking.global.exception.ResponseCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/promotions")
+public class PromotionsController {
+
+    private final PromotionsService promotionsService;
+
+    @Autowired
+    public PromotionsController(PromotionsService promotionsService) {
+        this.promotionsService = promotionsService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO> getPromotions() {
+
+        PromotionsResponseDTO promotionsResponseDTO = promotionsService.getPromotions();
+
+        return ResponseEntity
+                .status(ResponseCode.SUCCESS.getStatus().value())
+                .body(new ResponseDTO<>(ResponseCode.SUCCESS, promotionsResponseDTO));
+    }
+}

--- a/src/main/java/com/f012r/naverbooking/domain/promotions/dto/PromotionsResponseDTO.java
+++ b/src/main/java/com/f012r/naverbooking/domain/promotions/dto/PromotionsResponseDTO.java
@@ -1,0 +1,22 @@
+package com.f012r.naverbooking.domain.promotions.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PromotionsResponseDTO {
+
+    private int totalCount;
+    private List<PromotionsResponseDTO.PromotionDTO> items;
+
+    @Getter
+    @Builder
+    public static class PromotionDTO {
+        private int id;
+        private int productId;
+        private String productImageUrl;
+    }
+}

--- a/src/main/java/com/f012r/naverbooking/domain/promotions/entity/Promotion.java
+++ b/src/main/java/com/f012r/naverbooking/domain/promotions/entity/Promotion.java
@@ -1,0 +1,22 @@
+package com.f012r.naverbooking.domain.promotions.entity;
+
+import com.f012r.naverbooking.domain.products.entity.Product;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "promotion")
+public class Promotion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+}

--- a/src/main/java/com/f012r/naverbooking/domain/promotions/repository/PromotionsRepository.java
+++ b/src/main/java/com/f012r/naverbooking/domain/promotions/repository/PromotionsRepository.java
@@ -1,0 +1,7 @@
+package com.f012r.naverbooking.domain.promotions.repository;
+
+import com.f012r.naverbooking.domain.promotions.entity.Promotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PromotionsRepository  extends JpaRepository<Promotion, Integer> {
+}

--- a/src/main/java/com/f012r/naverbooking/domain/promotions/service/PromotionsService.java
+++ b/src/main/java/com/f012r/naverbooking/domain/promotions/service/PromotionsService.java
@@ -1,0 +1,67 @@
+package com.f012r.naverbooking.domain.promotions.service;
+
+import com.f012r.naverbooking.domain.products.entity.FileInfo;
+import com.f012r.naverbooking.domain.products.entity.Product;
+import com.f012r.naverbooking.domain.products.entity.ProductImage;
+import com.f012r.naverbooking.domain.products.repository.ProductImageRepository;
+import com.f012r.naverbooking.domain.promotions.dto.PromotionsResponseDTO;
+import com.f012r.naverbooking.domain.promotions.entity.Promotion;
+import com.f012r.naverbooking.domain.promotions.repository.PromotionsRepository;
+import com.f012r.naverbooking.global.exception.ResponseCode;
+import com.f012r.naverbooking.global.exception.custom.ImageNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PromotionsService {
+
+    private PromotionsRepository promotionsRepository;
+    private ProductImageRepository productImageRepository;
+
+    @Autowired
+    public PromotionsService(PromotionsRepository promotionsRepository,
+                             ProductImageRepository productImageRepository) {
+        this.promotionsRepository = promotionsRepository;
+        this.productImageRepository = productImageRepository;
+    }
+
+    public PromotionsResponseDTO getPromotions() {
+        List<PromotionsResponseDTO.PromotionDTO> promotionDTOList = new ArrayList<>();
+        List<Promotion> promotions = promotionsRepository.findAll();
+
+        for (Promotion promotion : promotions) {
+            int promotionId = promotion.getId();
+            int productId;
+            String productImageUrl;
+
+            Product promotionedProduct = promotion.getProduct();
+            productId = promotionedProduct.getId();
+
+            Optional<ProductImage> productImageOptional = productImageRepository.findFirstByProductAndType(promotionedProduct, "th");
+            if (productImageOptional.isPresent()) {
+                ProductImage productImage = productImageOptional.get();
+                FileInfo file = productImage.getFile();
+                productImageUrl = file.getSaveFileName();
+            } else {
+                throw new ImageNotFoundException(ResponseCode.ImageNotFoundException);
+            }
+
+            PromotionsResponseDTO.PromotionDTO promotionDTO = PromotionsResponseDTO.PromotionDTO.builder()
+                    .id(promotionId)
+                    .productId(productId)
+                    .productImageUrl("/" + productImageUrl)
+                    .build();
+
+            promotionDTOList.add(promotionDTO);
+        }
+
+        return PromotionsResponseDTO.builder()
+                .totalCount(promotions.size())
+                .items(promotionDTOList)
+                .build();
+    }
+}

--- a/src/main/java/com/f012r/naverbooking/global/exception/ResponseCode.java
+++ b/src/main/java/com/f012r/naverbooking/global/exception/ResponseCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ResponseCode {
 
     SUCCESS(HttpStatus.OK, "OK"),
+
+    ImageNotFoundException(HttpStatus.NOT_FOUND, "Image Not Found"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/f012r/naverbooking/global/exception/custom/ImageNotFoundException.java
+++ b/src/main/java/com/f012r/naverbooking/global/exception/custom/ImageNotFoundException.java
@@ -1,0 +1,10 @@
+package com.f012r.naverbooking.global.exception.custom;
+
+import com.f012r.naverbooking.global.exception.ResponseCode;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ImageNotFoundException extends RuntimeException {
+
+    private ResponseCode responseCode;
+}

--- a/src/test/java/com/f012r/naverbooking/domain/promotions/service/PromotionsServiceTest.java
+++ b/src/test/java/com/f012r/naverbooking/domain/promotions/service/PromotionsServiceTest.java
@@ -1,0 +1,50 @@
+package com.f012r.naverbooking.domain.promotions.service;
+
+import com.f012r.naverbooking.domain.products.entity.Product;
+import com.f012r.naverbooking.domain.products.repository.ProductImageRepository;
+import com.f012r.naverbooking.domain.promotions.entity.Promotion;
+import com.f012r.naverbooking.domain.promotions.repository.PromotionsRepository;
+import com.f012r.naverbooking.global.exception.custom.ImageNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class PromotionsServiceTest {
+
+    @InjectMocks
+    private PromotionsService promotionsService;
+
+    @Mock
+    private ProductImageRepository productImageRepository;
+
+    @Mock
+    private PromotionsRepository promotionsRepository;
+
+    @Test
+    public void testGetPromotions_ImageNotFoundException() {
+        // given
+        Product product = new Product();
+        product.setId(1);
+        Promotion promotion = new Promotion();
+        promotion.setId(1);
+        promotion.setProduct(product);
+
+        Mockito.when(promotionsRepository.findAll()).thenReturn(Collections.singletonList(promotion));
+        Mockito.when(productImageRepository.findFirstByProductAndType(product, "th")).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(ImageNotFoundException.class, () -> {
+            promotionsService.getPromotions();
+        });
+    }
+}
+


### PR DESCRIPTION
## 🛠️ 작업내용
<!-- 무엇을 변경하거나 추가했는지 설명해주세요. -->
- 프로모션 목록 조회 기능 추가
- 프로모션 썸네일 이미지 없을 시 예외를 throw 하는지 테스트 코드 추가

## 📜 이슈번호
<!-- #이슈번호를 작성해주세요. -->
close #3 

## 🔌 Jira 이슈코드
<!-- NB로 시작하는 Jira 이슈코드를 작성해주세요. -->
[NB-19]

## 📢 전달사항
<!-- PR과 관련된 내용 공유 또는 리뷰어에 대한 요청사항을 작성해주세요. -->

- 프로모션 썸네일 이미지를 불러오는 방법:
로컬에서 서버를 실행하면,
각 productImageUrl 값은 서버 도메인을 기준으로 접근할 수 있습니다.
예를 들어, productImageUrl이 "/img/1_th_1.png"인 경우,
로컬 서버에서 해당 이미지는 "http://localhost:8080/img/1_th_1.png" 주소를 통해 불러올 수 있습니다.

[NB-19]: https://2025-mini-project.atlassian.net/browse/NB-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ